### PR TITLE
Fix nil preference handling in activity patch

### DIFF
--- a/lib/westaco_activity_tab/patches/activities_controller_patch.rb
+++ b/lib/westaco_activity_tab/patches/activities_controller_patch.rb
@@ -56,7 +56,7 @@ module WestacoActivityTab
               end
             else
               if @author.nil?
-                scope = pref.activity_scope & @activity.event_types
+                scope = Array(pref.activity_scope) & @activity.event_types
                 @activity.scope = scope.present? ? scope : :default
               else
                 @activity.scope = :all


### PR DESCRIPTION
## Summary
- guard against `nil` user preferences when determining activity scopes

## Testing
- `ruby -c lib/redmine/activity/fetcher_patch.rb`
- `ruby -c lib/redmine/acts/activity_provider_patch.rb`
- `ruby -c lib/westaco_activity_tab/patches/activities_controller_patch.rb`
- `find . -name '*.rb' -print0 | xargs -0 -n1 ruby -c`

------
https://chatgpt.com/codex/tasks/task_e_6881390ac21c833299a96a7dc527c415