### PR TITLE
Fix date range format in activity filter

### DIFF
--- a/lib/westaco_activity_tab/patches/activities_controller_patch.rb
+++ b/lib/westaco_activity_tab/patches/activities_controller_patch.rb
@@ -37,7 +37,7 @@ module WestacoActivityTab
               @query.add_filter 'author_id', '=', [params[:user_id]]
             end
 
-            @query.add_filter 'updated_on', '><', [(@date_from - 1).to_s, (@date_to - 1).to_s(:db)]
+            @query.add_filter 'updated_on', '><', [(@date_from - 1).to_s(:db), (@date_to - 1).to_s(:db)]
 
             @activity = Redmine::Activity::Fetcher.new(
               User.current,


### PR DESCRIPTION
## Summary
- ensure both dates in the `updated_on` filter use DB format

## Testing
- `ruby -c lib/westaco_activity_tab/patches/activities_controller_patch.rb`


------
https://chatgpt.com/codex/tasks/task_e_68814137bf488332a8ccd7642eb1b820