### PR TITLE
Add ActivityQuery unit test

### DIFF
--- a/test/unit/activity_query_test.rb
+++ b/test/unit/activity_query_test.rb
@@ -1,0 +1,16 @@
+require File.expand_path('../test_helper', __dir__)
+
+class ActivityQueryTest < ActiveSupport::TestCase
+  def test_initialize_available_filters_sets_updated_on_filter_once
+    query = ActivityQuery.new
+    query.initialize_available_filters
+
+    assert query.available_filters.key?('updated_on'), 'updated_on filter should be present'
+    assert_equal 1, query.available_filters.keys.count { |k| k == 'updated_on' }, 'updated_on filter should be defined only once'
+
+    filter = query.available_filters['updated_on']
+    assert_not_nil filter, 'updated_on filter should not be nil'
+    assert_equal :date_past, filter[:type]
+    assert_equal I18n.t(:label_activity_date), filter[:name]
+  end
+end


### PR DESCRIPTION
## Summary
- create `test/unit/activity_query_test.rb` for `ActivityQuery`
- test that `initialize_available_filters` sets the `updated_on` filter exactly once with correct options

## Testing
- `ruby -Itest test/unit/activity_query_test.rb` *(fails: cannot load such file -- /test/test_helper)*

------
https://chatgpt.com/codex/tasks/task_e_6881412d0f04833294cb57983cf52a38