### PR TITLE
Remove duplicate updated_on filter

### DIFF
--- a/app/models/activity_query.rb
+++ b/app/models/activity_query.rb
@@ -45,7 +45,6 @@ class ActivityQuery < Query
     add_available_filter "description", :type => :text
     add_available_filter "notes", :type => :text
     add_available_filter "created_on", :type => :date_past
-    add_available_filter "updated_on", :type => :date_past
     add_available_filter "updated_on", :type => :date_past, :name => l(:label_activity_date)
     add_available_filter "closed_on", :type => :date_past
     add_available_filter "start_date", :type => :date


### PR DESCRIPTION
## Summary
- drop redundant `add_available_filter 'updated_on'` in `ActivityQuery`

## Testing
- `rake -T` *(fails: No Rakefile found)*

------
https://chatgpt.com/codex/tasks/task_e_688146066cdc8332893a62f3189db5a8