### PR TITLE
Switch to require_relative in init

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
-require File.dirname(__FILE__) + '/lib/redmine/activity/fetcher_patch.rb'
-require File.dirname(__FILE__) + '/lib/redmine/acts/activity_provider_patch.rb'
-require File.dirname(__FILE__) + '/lib/westaco_activity_tab/patches/activities_controller_patch.rb'
+require_relative 'lib/redmine/activity/fetcher_patch'
+require_relative 'lib/redmine/acts/activity_provider_patch'
+require_relative 'lib/westaco_activity_tab/patches/activities_controller_patch'
 
 Redmine::Plugin.register :westaco_activity_tab do
   name 'Westaco Activity Tab plugin'


### PR DESCRIPTION
## Summary
- use `require_relative` for plugin patch files

## Testing
- `ruby -c init.rb`


------
https://chatgpt.com/codex/tasks/task_e_6881460403888332aaa1af95ce026663